### PR TITLE
feat: support cloudwatch composite alarm monitoring

### DIFF
--- a/src/lambda/check-alarm-status/alarm-status-checker.ts
+++ b/src/lambda/check-alarm-status/alarm-status-checker.ts
@@ -18,7 +18,7 @@ export enum AlarmStatus {
 }
 
 export class AlarmStatusChecker {
-  constructor(private readonly cloudwatch: CloudWatch) {}
+  constructor(private readonly cloudwatch: CloudWatch) { }
 
   async checkStatus(input: CheckAlarmStatusRequest) {
     console.info('Parsing the input');
@@ -34,6 +34,7 @@ export class AlarmStatusChecker {
     const alarms = await this.cloudwatch.describeAlarms({
       AlarmNames: alarmNames,
       StateValue: 'ALARM',
+      AlarmTypes: ['CompositeAlarm', 'MetricAlarm'],
     }).promise();
 
     console.info('Alarm info =', alarms);

--- a/src/lambda/check-alarm-status/alarm-status-checker.ts
+++ b/src/lambda/check-alarm-status/alarm-status-checker.ts
@@ -39,7 +39,8 @@ export class AlarmStatusChecker {
 
     console.info('Alarm info =', alarms);
 
-    if ((alarms.MetricAlarms ?? []).length > 0) {
+    const totalAlarms = (alarms.MetricAlarms ?? []).length + (alarms.CompositeAlarms ?? []).length;
+    if (totalAlarms > 0) {
       console.warn('Alarm is in an alarming state');
       return {
         Status: AlarmStatus.Alarm,

--- a/test/integ/__snapshots__/integ.alarm-monitor.test.ts.snap
+++ b/test/integ/__snapshots__/integ.alarm-monitor.test.ts.snap
@@ -127,16 +127,16 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
-      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
+      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
       "Type": "String",
     },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
-      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
+      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
       "Type": "String",
     },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
-      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
+      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -161,7 +161,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -174,7 +174,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -187,7 +187,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.alarm-monitor.test.ts.snap
+++ b/test/integ/__snapshots__/integ.alarm-monitor.test.ts.snap
@@ -96,47 +96,17 @@ Object {
       },
     },
   },
-  "Outputs": Object {
-    "TestAlarmsAlwaysAlarmingExecution4B32A340": Object {
-      "Value": Object {
-        "Fn::Join": Array [
-          "",
-          Array [
-            "{\\"AlarmName\\":\\"",
-            Object {
-              "Ref": "TestAlarmsAlwaysAlarming69FED027",
-            },
-            "\\",\\"MonitoringSeconds\\":31}",
-          ],
-        ],
-      },
-    },
-    "TestAlarmsNeverAlarmingExecutionF5D1776E": Object {
-      "Value": Object {
-        "Fn::Join": Array [
-          "",
-          Array [
-            "{\\"AlarmName\\":\\"",
-            Object {
-              "Ref": "TestAlarmsNeverAlarmingHopefullyFD878B05",
-            },
-            "\\",\\"MonitoringSeconds\\":60}",
-          ],
-        ],
-      },
-    },
-  },
   "Parameters": Object {
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
-      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
+      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
       "Type": "String",
     },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
-      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
+      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
       "Type": "String",
     },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
-      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
+      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -161,7 +131,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -174,7 +144,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -187,7 +157,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -512,6 +482,55 @@ Object {
         "TreatMissingData": "breaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "TestAlarmsCompositeAlwaysAlarmingA7E34597": Object {
+      "Properties": Object {
+        "AlarmName": "IntegAlarmMonitorTestAlarmsCompositeAlwaysAlarming2A3007AE",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TestAlarmsAlwaysAlarming69FED027",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TestAlarmsNeverAlarmingHopefullyFD878B05",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+    "TestAlarmsCompositeNeverAlarming02CDF5B3": Object {
+      "Properties": Object {
+        "AlarmName": "IntegAlarmMonitorTestAlarmsCompositeNeverAlarming88E1B001",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TestAlarmsNeverAlarmingHopefullyFD878B05",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
     },
     "TestAlarmsNeverAlarmingHopefullyFD878B05": Object {
       "Properties": Object {

--- a/test/integ/__snapshots__/integ.alarm-monitor.test.ts.snap
+++ b/test/integ/__snapshots__/integ.alarm-monitor.test.ts.snap
@@ -127,16 +127,16 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbArtifactHashC86F80F3": Object {
-      "Description": "Artifact hash for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
+      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB": Object {
-      "Description": "S3 bucket for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
+      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292": Object {
-      "Description": "S3 key for asset version \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
+      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -161,7 +161,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -174,7 +174,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -187,7 +187,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.alarm-monitor.test.ts.snap
+++ b/test/integ/__snapshots__/integ.alarm-monitor.test.ts.snap
@@ -97,16 +97,16 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
-      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3ArtifactHash46F0CCEE": Object {
+      "Description": "Artifact hash for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
-      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA": Object {
+      "Description": "S3 bucket for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
-      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62": Object {
+      "Description": "S3 key for asset version \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -131,7 +131,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -144,7 +144,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -157,7 +157,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.cloudwatch-alarm.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.cloudwatch-alarm.lit.test.ts.snap
@@ -127,6 +127,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
+      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
+      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
+      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -137,18 +149,6 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
-      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
-      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
-      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -186,7 +186,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -199,7 +199,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -212,7 +212,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -379,7 +379,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -392,7 +392,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -405,7 +405,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -1509,7 +1509,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1522,7 +1522,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -1535,7 +1535,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.cloudwatch-alarm.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.cloudwatch-alarm.lit.test.ts.snap
@@ -139,16 +139,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbArtifactHashC86F80F3": Object {
-      "Description": "Artifact hash for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
+      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB": Object {
-      "Description": "S3 bucket for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
+      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292": Object {
-      "Description": "S3 key for asset version \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
+      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -186,7 +186,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -199,7 +199,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -212,7 +212,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -379,7 +379,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -392,7 +392,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -405,7 +405,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -1509,7 +1509,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1522,7 +1522,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -1535,7 +1535,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.cloudwatch-alarm.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.cloudwatch-alarm.lit.test.ts.snap
@@ -96,49 +96,7 @@ Object {
       },
     },
   },
-  "Outputs": Object {
-    "TestAlarmsAlwaysAlarmingExecution4B32A340": Object {
-      "Value": Object {
-        "Fn::Join": Array [
-          "",
-          Array [
-            "{\\"AlarmName\\":\\"",
-            Object {
-              "Ref": "TestAlarmsAlwaysAlarming69FED027",
-            },
-            "\\",\\"MonitoringSeconds\\":31}",
-          ],
-        ],
-      },
-    },
-    "TestAlarmsNeverAlarmingExecutionF5D1776E": Object {
-      "Value": Object {
-        "Fn::Join": Array [
-          "",
-          Array [
-            "{\\"AlarmName\\":\\"",
-            Object {
-              "Ref": "TestAlarmsNeverAlarmingHopefullyFD878B05",
-            },
-            "\\",\\"MonitoringSeconds\\":60}",
-          ],
-        ],
-      },
-    },
-  },
   "Parameters": Object {
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
-      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
-      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
-      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -149,6 +107,18 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
+      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
+      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
+      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -186,7 +156,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -199,7 +169,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -212,7 +182,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -379,7 +349,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -392,7 +362,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -405,7 +375,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -1251,15 +1221,15 @@ Object {
               },
               ":states:::states:startExecution.sync:2\\",\\"Parameters\\":{\\"Input\\":{\\"AlarmName\\":\\"",
               Object {
-                "Ref": "TestAlarmsNeverAlarmingHopefullyFD878B05",
+                "Ref": "TestAlarmsCompositeNeverAlarming02CDF5B3",
               },
-              "\\",\\"MonitoringDurationSeconds\\":300},\\"StateMachineArn\\":\\"",
+              "\\",\\"MonitoringDurationSeconds\\":60},\\"StateMachineArn\\":\\"",
               Object {
                 "Ref": "SingletonAlarmMonitorStateMachine9830D808",
               },
               "\\"}},\\"[0] MonitorAlarm - Alarming\\":{\\"Type\\":\\"Fail\\",\\"Error\\":\\"Alarm\\",\\"Cause\\":\\"",
               Object {
-                "Ref": "TestAlarmsNeverAlarmingHopefullyFD878B05",
+                "Ref": "TestAlarmsCompositeNeverAlarming02CDF5B3",
               },
               " is alarming\\"}}}]}}}",
             ],
@@ -1509,7 +1479,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1522,7 +1492,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -1535,7 +1505,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -1750,6 +1720,55 @@ Object {
         "TreatMissingData": "breaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "TestAlarmsCompositeAlwaysAlarmingA7E34597": Object {
+      "Properties": Object {
+        "AlarmName": "IntegCloudwatchAlarmLitTestAlarmsCompositeAlwaysAlarming50AFE6C8",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TestAlarmsAlwaysAlarming69FED027",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TestAlarmsNeverAlarmingHopefullyFD878B05",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+    "TestAlarmsCompositeNeverAlarming02CDF5B3": Object {
+      "Properties": Object {
+        "AlarmName": "IntegCloudwatchAlarmLitTestAlarmsCompositeNeverAlarming3EB5135B",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TestAlarmsNeverAlarmingHopefullyFD878B05",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
     },
     "TestAlarmsNeverAlarmingHopefullyFD878B05": Object {
       "Properties": Object {

--- a/test/integ/__snapshots__/integ.cloudwatch-alarm.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.cloudwatch-alarm.lit.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
-      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3ArtifactHash46F0CCEE": Object {
+      "Description": "Artifact hash for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
-      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA": Object {
+      "Description": "S3 bucket for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
-      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62": Object {
+      "Description": "S3 key for asset version \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -156,7 +156,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -169,7 +169,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -182,7 +182,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -349,7 +349,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -362,7 +362,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -375,7 +375,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -1479,7 +1479,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1492,7 +1492,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -1505,7 +1505,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.dev.test.ts.snap
+++ b/test/integ/__snapshots__/integ.dev.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
-      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3ArtifactHash46F0CCEE": Object {
+      "Description": "Artifact hash for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
-      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA": Object {
+      "Description": "S3 bucket for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
-      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62": Object {
+      "Description": "S3 key for asset version \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -738,7 +738,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -751,7 +751,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -764,7 +764,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -931,7 +931,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -944,7 +944,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -957,7 +957,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -2422,7 +2422,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2435,7 +2435,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -2448,7 +2448,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.dev.test.ts.snap
+++ b/test/integ/__snapshots__/integ.dev.test.ts.snap
@@ -96,49 +96,7 @@ Object {
       },
     },
   },
-  "Outputs": Object {
-    "TestAlarmsAlwaysAlarmingExecution4B32A340": Object {
-      "Value": Object {
-        "Fn::Join": Array [
-          "",
-          Array [
-            "{\\"AlarmName\\":\\"",
-            Object {
-              "Ref": "TestAlarmsAlwaysAlarming69FED027",
-            },
-            "\\",\\"MonitoringSeconds\\":31}",
-          ],
-        ],
-      },
-    },
-    "TestAlarmsNeverAlarmingExecutionF5D1776E": Object {
-      "Value": Object {
-        "Fn::Join": Array [
-          "",
-          Array [
-            "{\\"AlarmName\\":\\"",
-            Object {
-              "Ref": "TestAlarmsNeverAlarmingHopefullyFD878B05",
-            },
-            "\\",\\"MonitoringSeconds\\":60}",
-          ],
-        ],
-      },
-    },
-  },
   "Parameters": Object {
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
-      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
-      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
-      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -149,6 +107,18 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
+      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
+      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
+      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -768,7 +738,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -781,7 +751,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -794,7 +764,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -961,7 +931,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -974,7 +944,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -987,7 +957,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -2452,7 +2422,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2465,7 +2435,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -2478,7 +2448,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -2693,6 +2663,55 @@ def handler(event, context):
         "TreatMissingData": "breaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "TestAlarmsCompositeAlwaysAlarmingA7E34597": Object {
+      "Properties": Object {
+        "AlarmName": "IntegDevTestAlarmsCompositeAlwaysAlarmingC47956CE",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TestAlarmsAlwaysAlarming69FED027",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TestAlarmsNeverAlarmingHopefullyFD878B05",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+    "TestAlarmsCompositeNeverAlarming02CDF5B3": Object {
+      "Properties": Object {
+        "AlarmName": "IntegDevTestAlarmsCompositeNeverAlarming765D9E6E",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TestAlarmsNeverAlarmingHopefullyFD878B05",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
     },
     "TestAlarmsNeverAlarmingHopefullyFD878B05": Object {
       "Properties": Object {

--- a/test/integ/__snapshots__/integ.dev.test.ts.snap
+++ b/test/integ/__snapshots__/integ.dev.test.ts.snap
@@ -139,16 +139,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbArtifactHashC86F80F3": Object {
-      "Description": "Artifact hash for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
+      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB": Object {
-      "Description": "S3 bucket for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
+      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292": Object {
-      "Description": "S3 key for asset version \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
+      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -768,7 +768,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -781,7 +781,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -794,7 +794,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -961,7 +961,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -974,7 +974,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -987,7 +987,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -2452,7 +2452,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2465,7 +2465,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -2478,7 +2478,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.dev.test.ts.snap
+++ b/test/integ/__snapshots__/integ.dev.test.ts.snap
@@ -127,6 +127,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
+      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
+      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
+      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -137,18 +149,6 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
-      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
-      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
-      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -768,7 +768,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -781,7 +781,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -794,7 +794,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -961,7 +961,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -974,7 +974,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -987,7 +987,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -2452,7 +2452,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -2465,7 +2465,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -2478,7 +2478,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.error-message.test.ts.snap
+++ b/test/integ/__snapshots__/integ.error-message.test.ts.snap
@@ -127,6 +127,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
+      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
+      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
+      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -137,18 +149,6 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
-      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
-      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
-      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -678,7 +678,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -691,7 +691,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -704,7 +704,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -871,7 +871,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -884,7 +884,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -897,7 +897,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -1885,7 +1885,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1898,7 +1898,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -1911,7 +1911,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.error-message.test.ts.snap
+++ b/test/integ/__snapshots__/integ.error-message.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
-      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3ArtifactHash46F0CCEE": Object {
+      "Description": "Artifact hash for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
-      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA": Object {
+      "Description": "S3 bucket for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
-      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62": Object {
+      "Description": "S3 key for asset version \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -648,7 +648,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -661,7 +661,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -674,7 +674,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -841,7 +841,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -854,7 +854,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -867,7 +867,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -1855,7 +1855,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1868,7 +1868,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -1881,7 +1881,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.error-message.test.ts.snap
+++ b/test/integ/__snapshots__/integ.error-message.test.ts.snap
@@ -96,49 +96,7 @@ Object {
       },
     },
   },
-  "Outputs": Object {
-    "TestAlarmsAlwaysAlarmingExecution4B32A340": Object {
-      "Value": Object {
-        "Fn::Join": Array [
-          "",
-          Array [
-            "{\\"AlarmName\\":\\"",
-            Object {
-              "Ref": "TestAlarmsAlwaysAlarming69FED027",
-            },
-            "\\",\\"MonitoringSeconds\\":31}",
-          ],
-        ],
-      },
-    },
-    "TestAlarmsNeverAlarmingExecutionF5D1776E": Object {
-      "Value": Object {
-        "Fn::Join": Array [
-          "",
-          Array [
-            "{\\"AlarmName\\":\\"",
-            Object {
-              "Ref": "TestAlarmsNeverAlarmingHopefullyFD878B05",
-            },
-            "\\",\\"MonitoringSeconds\\":60}",
-          ],
-        ],
-      },
-    },
-  },
   "Parameters": Object {
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
-      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
-      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
-      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -149,6 +107,18 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
+      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
+      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
+      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -678,7 +648,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -691,7 +661,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -704,7 +674,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -871,7 +841,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -884,7 +854,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -897,7 +867,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -1885,7 +1855,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1898,7 +1868,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -1911,7 +1881,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -2126,6 +2096,55 @@ def handler(event, context):
         "TreatMissingData": "breaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "TestAlarmsCompositeAlwaysAlarmingA7E34597": Object {
+      "Properties": Object {
+        "AlarmName": "IntegErrorMessageTestAlarmsCompositeAlwaysAlarming8F79650A",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TestAlarmsAlwaysAlarming69FED027",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TestAlarmsNeverAlarmingHopefullyFD878B05",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+    "TestAlarmsCompositeNeverAlarming02CDF5B3": Object {
+      "Properties": Object {
+        "AlarmName": "IntegErrorMessageTestAlarmsCompositeNeverAlarming7066A320",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "TestAlarmsNeverAlarmingHopefullyFD878B05",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
     },
     "TestAlarmsNeverAlarmingHopefullyFD878B05": Object {
       "Properties": Object {

--- a/test/integ/__snapshots__/integ.error-message.test.ts.snap
+++ b/test/integ/__snapshots__/integ.error-message.test.ts.snap
@@ -139,16 +139,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbArtifactHashC86F80F3": Object {
-      "Description": "Artifact hash for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
+      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB": Object {
-      "Description": "S3 bucket for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
+      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292": Object {
-      "Description": "S3 key for asset version \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
+      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -678,7 +678,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -691,7 +691,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -704,7 +704,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -871,7 +871,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -884,7 +884,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -897,7 +897,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -1885,7 +1885,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1898,7 +1898,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -1911,7 +1911,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.fargate-puppeteer.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.fargate-puppeteer.lit.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
-      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3ArtifactHash46F0CCEE": Object {
+      "Description": "Artifact hash for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
-      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA": Object {
+      "Description": "S3 bucket for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
-      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62": Object {
+      "Description": "S3 key for asset version \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -542,7 +542,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -555,7 +555,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -568,7 +568,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -735,7 +735,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -748,7 +748,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -761,7 +761,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.fargate-puppeteer.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.fargate-puppeteer.lit.test.ts.snap
@@ -97,18 +97,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
-      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
-      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
-      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -119,6 +107,18 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
+      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
+      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
+      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -542,7 +542,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -555,7 +555,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -568,7 +568,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -735,7 +735,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -748,7 +748,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -761,7 +761,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.fargate-puppeteer.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.fargate-puppeteer.lit.test.ts.snap
@@ -97,6 +97,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
+      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
+      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
+      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -107,18 +119,6 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
-      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
-      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
-      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -542,7 +542,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -555,7 +555,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -568,7 +568,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -735,7 +735,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -748,7 +748,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -761,7 +761,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.fargate-puppeteer.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.fargate-puppeteer.lit.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbArtifactHashC86F80F3": Object {
-      "Description": "Artifact hash for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
+      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB": Object {
-      "Description": "S3 bucket for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
+      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292": Object {
-      "Description": "S3 key for asset version \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
+      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -542,7 +542,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -555,7 +555,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -568,7 +568,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -735,7 +735,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -748,7 +748,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -761,7 +761,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.fargate.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.fargate.lit.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
-      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3ArtifactHash46F0CCEE": Object {
+      "Description": "Artifact hash for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
-      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA": Object {
+      "Description": "S3 bucket for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
-      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62": Object {
+      "Description": "S3 key for asset version \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -542,7 +542,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -555,7 +555,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -568,7 +568,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -735,7 +735,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -748,7 +748,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -761,7 +761,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.fargate.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.fargate.lit.test.ts.snap
@@ -97,18 +97,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
-      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
-      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
-      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -119,6 +107,18 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
+      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
+      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
+      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -542,7 +542,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -555,7 +555,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -568,7 +568,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -735,7 +735,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -748,7 +748,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -761,7 +761,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.fargate.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.fargate.lit.test.ts.snap
@@ -97,6 +97,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
+      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
+      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
+      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -107,18 +119,6 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
-      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
-      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
-      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -542,7 +542,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -555,7 +555,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -568,7 +568,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -735,7 +735,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -748,7 +748,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -761,7 +761,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.fargate.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.fargate.lit.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbArtifactHashC86F80F3": Object {
-      "Description": "Artifact hash for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
+      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB": Object {
-      "Description": "S3 bucket for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
+      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292": Object {
-      "Description": "S3 key for asset version \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
+      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -542,7 +542,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -555,7 +555,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -568,7 +568,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -735,7 +735,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -748,7 +748,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -761,7 +761,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.http-check.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.http-check.lit.test.ts.snap
@@ -97,18 +97,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
-      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
-      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
-      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -119,6 +107,18 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
+      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
+      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
+      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -156,7 +156,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -169,7 +169,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -182,7 +182,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -349,7 +349,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -362,7 +362,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -375,7 +375,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -1419,7 +1419,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1432,7 +1432,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -1445,7 +1445,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.http-check.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.http-check.lit.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
-      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3ArtifactHash46F0CCEE": Object {
+      "Description": "Artifact hash for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
-      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA": Object {
+      "Description": "S3 bucket for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
-      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62": Object {
+      "Description": "S3 key for asset version \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -156,7 +156,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -169,7 +169,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -182,7 +182,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -349,7 +349,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -362,7 +362,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -375,7 +375,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -1419,7 +1419,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1432,7 +1432,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -1445,7 +1445,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.http-check.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.http-check.lit.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbArtifactHashC86F80F3": Object {
-      "Description": "Artifact hash for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
+      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB": Object {
-      "Description": "S3 bucket for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
+      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292": Object {
-      "Description": "S3 key for asset version \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
+      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -156,7 +156,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -169,7 +169,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -182,7 +182,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -349,7 +349,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -362,7 +362,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -375,7 +375,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -1419,7 +1419,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1432,7 +1432,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -1445,7 +1445,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.http-check.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.http-check.lit.test.ts.snap
@@ -97,6 +97,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
+      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
+      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
+      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -107,18 +119,6 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
-      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
-      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
-      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -156,7 +156,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -169,7 +169,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -182,7 +182,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -349,7 +349,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -362,7 +362,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -375,7 +375,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -1419,7 +1419,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1432,7 +1432,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -1445,7 +1445,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.lambda.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.lambda.lit.test.ts.snap
@@ -97,6 +97,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
+      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
+      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
+      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -107,18 +119,6 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
-      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
-      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
-      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -262,7 +262,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -275,7 +275,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -288,7 +288,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -455,7 +455,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -468,7 +468,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -481,7 +481,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.lambda.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.lambda.lit.test.ts.snap
@@ -97,18 +97,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
-      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
-      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
-      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -119,6 +107,18 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
+      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
+      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
+      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -262,7 +262,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -275,7 +275,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -288,7 +288,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -455,7 +455,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -468,7 +468,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -481,7 +481,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.lambda.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.lambda.lit.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbArtifactHashC86F80F3": Object {
-      "Description": "Artifact hash for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
+      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB": Object {
-      "Description": "S3 bucket for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
+      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292": Object {
-      "Description": "S3 key for asset version \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
+      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -262,7 +262,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -275,7 +275,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -288,7 +288,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -455,7 +455,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -468,7 +468,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -481,7 +481,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.lambda.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.lambda.lit.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
-      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3ArtifactHash46F0CCEE": Object {
+      "Description": "Artifact hash for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
-      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA": Object {
+      "Description": "S3 bucket for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
-      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62": Object {
+      "Description": "S3 key for asset version \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -262,7 +262,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -275,7 +275,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -288,7 +288,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -455,7 +455,7 @@ def handler(event, context):
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -468,7 +468,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -481,7 +481,7 @@ def handler(event, context):
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.main.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.main.lit.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbArtifactHashC86F80F3": Object {
-      "Description": "Artifact hash for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
+      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB": Object {
-      "Description": "S3 bucket for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
+      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292": Object {
-      "Description": "S3 key for asset version \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
+      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -587,7 +587,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -600,7 +600,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -613,7 +613,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -780,7 +780,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -793,7 +793,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -806,7 +806,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.main.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.main.lit.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
-      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3ArtifactHash46F0CCEE": Object {
+      "Description": "Artifact hash for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
-      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA": Object {
+      "Description": "S3 bucket for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
-      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62": Object {
+      "Description": "S3 key for asset version \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -587,7 +587,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -600,7 +600,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -613,7 +613,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -780,7 +780,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -793,7 +793,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -806,7 +806,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.main.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.main.lit.test.ts.snap
@@ -97,18 +97,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
-      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
-      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
-      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -119,6 +107,18 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
+      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
+      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
+      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -587,7 +587,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -600,7 +600,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -613,7 +613,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -780,7 +780,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -793,7 +793,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -806,7 +806,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.main.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.main.lit.test.ts.snap
@@ -97,6 +97,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
+      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
+      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
+      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -107,18 +119,6 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
-      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
-      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
-      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -587,7 +587,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -600,7 +600,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -613,7 +613,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -780,7 +780,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -793,7 +793,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -806,7 +806,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.step-function.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.step-function.lit.test.ts.snap
@@ -97,18 +97,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
-      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
-      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
-    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
-      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
-      "Type": "String",
-    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -119,6 +107,18 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
+      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
+      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+      "Type": "String",
+    },
+    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
+      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -156,7 +156,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -169,7 +169,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -182,7 +182,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -349,7 +349,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
+            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -362,7 +362,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },
@@ -375,7 +375,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
+                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.step-function.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.step-function.lit.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbArtifactHashC86F80F3": Object {
-      "Description": "Artifact hash for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
+      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB": Object {
-      "Description": "S3 bucket for asset \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
+      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
-    "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292": Object {
-      "Description": "S3 key for asset version \\"942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bb\\"",
+    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
+      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -156,7 +156,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -169,7 +169,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -182,7 +182,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -349,7 +349,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3Bucket22A8D7BB",
+            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -362,7 +362,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },
@@ -375,7 +375,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters942a4effc6a5eb9e9052b826b9852fb36fb9d62cc202e71c8120b5e1541e16bbS3VersionKey691CB292",
+                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.step-function.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.step-function.lit.test.ts.snap
@@ -109,16 +109,16 @@ Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cArtifactHashE172E14D": Object {
-      "Description": "Artifact hash for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3ArtifactHash46F0CCEE": Object {
+      "Description": "Artifact hash for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02": Object {
-      "Description": "S3 bucket for asset \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA": Object {
+      "Description": "S3 bucket for asset \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
-    "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0": Object {
-      "Description": "S3 key for asset version \\"c7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4c\\"",
+    "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62": Object {
+      "Description": "S3 key for asset version \\"bbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -156,7 +156,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -169,7 +169,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -182,7 +182,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -349,7 +349,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3Bucket0DBF9D02",
+            "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3Bucket7B95C1BA",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -362,7 +362,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },
@@ -375,7 +375,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc7c8e179917686cb9c4f5ee68753c6c10b5746a5516eb528a103c660513b7f4cS3VersionKeyC05805C0",
+                          "Ref": "AssetParametersbbabe4652bcb9c2ce4bfd87c8803d55a7f0fc19d7c7b20f97f03ed47c60968f3S3VersionKey556E5A62",
                         },
                       ],
                     },

--- a/test/integ/__snapshots__/integ.step-function.lit.test.ts.snap
+++ b/test/integ/__snapshots__/integ.step-function.lit.test.ts.snap
@@ -97,6 +97,18 @@ Object {
     },
   },
   "Parameters": Object {
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8ArtifactHash4F60A775": Object {
+      "Description": "Artifact hash for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033": Object {
+      "Description": "S3 bucket for asset \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
+    "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205": Object {
+      "Description": "S3 key for asset version \\"6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8\\"",
+      "Type": "String",
+    },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9ArtifactHash26B5BCAA": Object {
       "Description": "Artifact hash for asset \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
       "Type": "String",
@@ -107,18 +119,6 @@ Object {
     },
     "AssetParameters8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9S3VersionKey36104212": Object {
       "Description": "S3 key for asset version \\"8dd02cc4ac473ca5b08800e92edaa31a1a7db4005928021d029c5363584f11b9\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddArtifactHash36C1E5DC": Object {
-      "Description": "Artifact hash for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB": Object {
-      "Description": "S3 bucket for asset \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
-      "Type": "String",
-    },
-    "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8": Object {
-      "Description": "S3 key for asset version \\"c07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568dd\\"",
       "Type": "String",
     },
     "AssetParametersff11416d5596b03499b7d71853b288cd55b7162e49359ac6d037ad1902d674fdArtifactHash6E87626F": Object {
@@ -156,7 +156,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -169,7 +169,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -182,7 +182,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -349,7 +349,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3Bucket98DB47BB",
+            "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3Bucket25BAB033",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -362,7 +362,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },
@@ -375,7 +375,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParametersc07a9a2f4ac76d1b60c74ac9e814cee6eda21b3a01432e49fcceaf33d83568ddS3VersionKey70EA59D8",
+                          "Ref": "AssetParameters6cb41dd3d114f80cf466dce4b16b8148c7f86051eeb919a53d84d6bf46c54cb8S3VersionKeyBB063205",
                         },
                       ],
                     },

--- a/test/integ/integ.cloudwatch-alarm.lit.ts
+++ b/test/integ/integ.cloudwatch-alarm.lit.ts
@@ -8,7 +8,7 @@ export class IntegCloudwatchAlarmLit extends cdk.Stack {
     super(scope_, 'IntegCloudwatchAlarmLit', props);
 
     const testAlarms = new TestAlarms(this, 'TestAlarms');
-    const alarm = testAlarms.neverAlarming;
+    const alarm = testAlarms.compositeNeverAlarming;
 
     // Lit code uses 'scope'
     const scope = this;
@@ -21,7 +21,7 @@ export class IntegCloudwatchAlarmLit extends cdk.Stack {
         // monitoring it, the stack will roll back automatically.
         Validation.monitorAlarm({
           alarm,
-          duration: cdk.Duration.minutes(5),
+          duration: cdk.Duration.minutes(1),
         }),
       ],
     });

--- a/test/integ/test-alarms.ts
+++ b/test/integ/test-alarms.ts
@@ -11,6 +11,9 @@ export class TestAlarms extends cdk.Construct {
   /** An alarm that is never in alarm */
   public readonly neverAlarming: cw.IAlarm;
 
+  public readonly compositeAlwaysAlarming: cw.IAlarm;
+  public readonly compositeNeverAlarming: cw.IAlarm;
+
   constructor(scope: cdk.Construct, id: string) {
     super(scope, id);
 
@@ -39,13 +42,6 @@ export class TestAlarms extends cdk.Construct {
       treatMissingData: cw.TreatMissingData.BREACHING,
     });
 
-    new cdk.CfnOutput(this, 'AlwaysAlarmingExecution', {
-      value: JSON.stringify({
-        AlarmName: this.alwaysAlarming.alarmName,
-        MonitoringSeconds: 31,
-      }),
-    });
-
     // This alarm shouldn't ever alarm.
     this.neverAlarming = new cw.Alarm(this, 'NeverAlarmingHopefully', {
       metric,
@@ -55,11 +51,14 @@ export class TestAlarms extends cdk.Construct {
       treatMissingData: cw.TreatMissingData.NOT_BREACHING,
     });
 
-    new cdk.CfnOutput(this, 'NeverAlarmingExecution', {
-      value: JSON.stringify({
-        AlarmName: this.neverAlarming.alarmName,
-        MonitoringSeconds: 60,
-      }),
+    // This composite alarm should always be alarming
+    this.compositeAlwaysAlarming = new cw.CompositeAlarm(this, 'CompositeAlwaysAlarming', {
+      alarmRule: cw.AlarmRule.anyOf(this.alwaysAlarming, this.neverAlarming),
+    });
+
+    // This composite alarm should never be alarming.
+    this.compositeNeverAlarming = new cw.CompositeAlarm(this, 'CompositeNeverAlarming', {
+      alarmRule: cw.AlarmRule.anyOf(this.neverAlarming),
     });
   }
 }


### PR DESCRIPTION
this change describes both composite and metric alarms when finding alarms in alarming state.

The default behaviour on the `DescribeAlarms` API call is to only include metric alarms in the response.

ref; https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CloudWatch.html#describeAlarms-property